### PR TITLE
Better quality setting

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,6 +6,7 @@
     "maxPendingSize": 50
   },
   "youtube-dl": [
+    "-f bestvideo[ext=mp4]+bestaudio[ext=m4a]/mp4",
     "--write-sub",
     "--write-auto-sub",
     "--sub-lang",


### PR DESCRIPTION
Improved the quality setting for youtube-dl, it will download the full 1080p while retaining the mp4 as the default until a possible web ui setting.

In a test it increased a 12 minute video's file by ~60mb but increased the picture quality to what a 1080p video would look like on Youtube.