### PR TITLE
Try using ADD instead of RUN to install youtube-dl.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest
 RUN apk add --update nodejs npm curl ffmpeg python
-RUN curl -L https://yt-dl.org/downloads/latest/youtube-dl -o /usr/local/bin/youtube-dl
+ADD https://yt-dl.org/downloads/latest/youtube-dl /usr/local/bin/youtube-dl
 RUN chmod a+rx /usr/local/bin/youtube-dl
 WORKDIR /app
 COPY . .

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "video-hoarder",
-  "version": "0.0.4-rc1",
+  "version": "0.0.4-rc2",
   "description": "youtube-dl frontend for NAS devices.",
   "main": "server/index.js",
   "scripts": {


### PR DESCRIPTION
Trying to get the docker image working again. Chanced upon this thread https://stackoverflow.com/questions/31171851/docker-build-add-vs-run-curl. Going to try `ADD` instead of `RUN curl`.