### PR TITLE
Add error handling to getTitle

### DIFF
--- a/client/components/task-filter.jsx
+++ b/client/components/task-filter.jsx
@@ -37,7 +37,7 @@ const TaskFilter = (props) =>
         </Button>
       </ButtonGroup>
     </div>
-    <Button variant="light" onClick={props.clearQueue} size="sm" className="task-filter__button--clear">
+    <Button variant="warning" onClick={props.clearQueue} size="sm" className="task-filter__button--clear">
       <label>🗑️</label>
       <label className="filter-button__label">Clear</label>
     </Button>

--- a/client/components/task-filter.less
+++ b/client/components/task-filter.less
@@ -10,10 +10,17 @@
     + .btn-group {
       margin-left: @margin-0;
     }
+
+    .btn + .btn {
+      border-left: 1px solid #000;
+    }
   }
 
   .btn {
     min-width: 6rem;
+    label {
+      margin: 0.25rem;
+    }
   }
 
   .filter-button__number {

--- a/client/components/task-output.less
+++ b/client/components/task-output.less
@@ -1,4 +1,5 @@
 .task-output {
   min-height: 10rem;
   max-height: 50vh;
+  padding: 1rem;
 }

--- a/client/components/tasks.jsx
+++ b/client/components/tasks.jsx
@@ -17,7 +17,7 @@ const Tasks = ({ tasks }) =>
   </div>
 
 Tasks.propTypes = {
-  tasks: PropTypes.arrayOf(PropTypes.Object)
+  tasks: PropTypes.arrayOf(PropTypes.object)
 };
 
 const mapStateToProps = (state) =>({

--- a/client/net.js
+++ b/client/net.js
@@ -36,8 +36,12 @@ const wireSocketToStore = ({ store }) => {
   });
 
   // TODO: match id for sanity?
-  socket.on(Event.TaskProgress, ({ id, output, stats }) => {
-    store.dispatch(updateTaskOutput(id, output));
+  socket.on(Event.TaskProgress, (args) => {
+    const { id, output, stats, multi } = args;
+    if (multi)
+      store.dispatch(updateTaskOutput({ multi }));
+    else
+      store.dispatch(updateTaskOutput({ id, output }));
     store.dispatch(updateTaskStats(id, stats));
   });
 }

--- a/client/redux/actions/index.js
+++ b/client/redux/actions/index.js
@@ -39,19 +39,27 @@ export const updateQueue = queue => ({
 /**
  * Appends given output to the existing output for the given task id.
  *
- * @param {string} taskId -
- * @param {string} output -
+ * @param {Array} [args.multi] - contains multiple task statuses
+ * @param {string} [args.id] - won't be supplied if multi is present
+ * @param {string} [args.output] - won't be supplied if multi is present
  * @returns {function} -
  */
-export const updateTaskOutput = (taskId, output) =>
+export const updateTaskOutput = (args) =>
   (dispatch, getState) => {
     const { taskOutput } = getState();
-    const currentOutput = taskOutput[taskId] || [];
-    const newOutput = [...currentOutput, output];
-    dispatch({
-      type: SetTaskOutput,
-      output: Object.assign({}, taskOutput, { [taskId]: newOutput })
-    });
+    const append = (id, output) => {
+      const currentOutput = taskOutput[id] || [];
+      const newOutput = [...currentOutput, ...output];
+      dispatch({
+        type: SetTaskOutput,
+        output: Object.assign({}, taskOutput, { [id]: newOutput })
+      });
+    }
+
+    if (args.multi)
+      args.multi.forEach(([id, output]) => append(id, output));
+    else
+      append(args.id, args.output);
   }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "video-hoarder",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1555,9 +1555,9 @@
       "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig=="
     },
     "bluebird": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
-      "integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "dev": true
     },
     "blueimp-md5": {
@@ -6815,9 +6815,9 @@
       }
     },
     "serialize-javascript": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
-      "integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
+      "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
       "dev": true
     },
     "serve-static": {
@@ -7179,9 +7179,9 @@
       }
     },
     "source-map-support": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
+      "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -7373,9 +7373,9 @@
       }
     },
     "stream-shift": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "dev": true
     },
     "string-width": {
@@ -7520,9 +7520,9 @@
       "dev": true
     },
     "terser": {
-      "version": "4.3.9",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.3.9.tgz",
-      "integrity": "sha512-NFGMpHjlzmyOtPL+fDw3G7+6Ueh/sz4mkaUYa4lJCxOPTNzd0Uj0aZJOmsDYoSQyfuVoWDMSWTPU3huyOm2zdA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.4.3.tgz",
+      "integrity": "sha512-0ikKraVtRDKGzHrzkCv5rUNDzqlhmhowOBqC0XqUHFpW+vJ45+20/IFBcebwKfiS2Z9fJin6Eo+F1zLZsxi8RA==",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",
@@ -7539,16 +7539,16 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.1.tgz",
-      "integrity": "sha512-ZXmmfiwtCLfz8WKZyYUuuHf3dMYEjg8NrjHMb0JqHVHVOSkzp3cW2/XG1fP3tRhqEqSzMwzzRQGtAPbs4Cncxg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
+      "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
       "dev": true,
       "requires": {
         "cacache": "^12.0.2",
         "find-cache-dir": "^2.1.0",
         "is-wsl": "^1.1.0",
         "schema-utils": "^1.0.0",
-        "serialize-javascript": "^1.7.0",
+        "serialize-javascript": "^2.1.2",
         "source-map": "^0.6.1",
         "terser": "^4.1.2",
         "webpack-sources": "^1.4.0",

--- a/server/event-handlers/index.mjs
+++ b/server/event-handlers/index.mjs
@@ -62,7 +62,11 @@ const bootstrapApp = io => {
     socket.on(Event.TaskAdded, onTaskAdded);
     socket.on(Event.AbortTask, onTaskAborted);
     socket.on(Event.ClearQueue, onClearQueue);
-    socket.emit(Event.QueueUpdated, Store.all());
+    const tasks = Store.all();
+    socket.emit(Event.QueueUpdated, tasks);
+    socket.emit(Event.TaskProgress, {
+      multi: Store.getAllOutput()
+    })
   });
 }
 

--- a/server/store.mjs
+++ b/server/store.mjs
@@ -68,3 +68,9 @@ export const remove = (id) => {
 export const all = () => Array.from(tasks.values());
 
 export const filter = fn => all().filter(fn);
+
+/**
+ * Returns an object mapping task-ids to task-output list.
+ * @returns {Array} -
+ */
+export const getAllOutput = () => Array.from(outputMap);


### PR DESCRIPTION
This commit adds error handling to getTitle(). Also tweaks things so that
1. Error messages actually make it to the task output.
2. Task output is supplied at client-bootstrap so that new sessions continue to show task output.
3. Added a `.multi` field to the task-output socket event. This was added to enable #2, but also opens the way for batching task updates in the future.

Also, upgraded to go past vulnerable version of serialize-javascript.