### PR TITLE
Feature:  batched status updates

### DIFF
--- a/ADR/0001-batched-status-updates.md
+++ b/ADR/0001-batched-status-updates.md
@@ -1,0 +1,21 @@
+# Batched status updates
+
+|      |                                                                          |
+|------|--------------------------------------------------------------------------|
+|Title |Batching of job status updates provided from graphql server to the client |
+|Tags  |Client, responsiveness, network, graphql, job-status                      |
+|Status|Committed                                                                 |
+|Date  |10th July, 2022                                                           |
+
+
+## Problem
+
+Currently, the server transmits progress updates for each job as an individual message on the websocket link. These messages are consumed by the client, which updates the progress and/or status for each job on the receipt of each message.
+
+This setup works OK for a small number of jobs, but as soon as the number of in-progress jobs rises, the client spends more and more time repainting the job list. This results in a client UI which becomes less and less responsive.
+
+## Proposed solution
+
+Job status updates received from the external downloader will no longer be immediatekly put on the websocket. Instead, these updates will be gathered in a short term buffer on the server. A separate code path will periodically check the buffer for contents, and transmit them as a single websocket message if any updates are found. Any updates sent to the client will be removed from the buffer.
+
+This will make the update (and therefore repaint) frequency on the client deterministic (and lower) which in turn will give us a more responsive UI.

--- a/ADR/0001-batched-status-updates.md
+++ b/ADR/0001-batched-status-updates.md
@@ -1,11 +1,11 @@
 # Batched status updates
 
-|      |                                                                          |
-|------|--------------------------------------------------------------------------|
-|Title |Batching of job status updates provided from graphql server to the client |
-|Tags  |Client, responsiveness, network, graphql, job-status                      |
-|Status|Committed                                                                 |
-|Date  |10th July, 2022                                                           |
+|        |                                                                           |
+|--------|---------------------------------------------------------------------------|
+| Title  | Batching of job status updates provided from graphql server to the client |
+| Tags   | Client, responsiveness, network, graphql, job-status                      |
+| Status | Committed                                                                 |
+| Date   | 10th July, 2022                                                           |
 
 
 ## Problem
@@ -19,3 +19,9 @@ This setup works OK for a small number of jobs, but as soon as the number of in-
 Job status updates received from the external downloader will no longer be immediatekly put on the websocket. Instead, these updates will be gathered in a short term buffer on the server. A separate code path will periodically check the buffer for contents, and transmit them as a single websocket message if any updates are found. Any updates sent to the client will be removed from the buffer.
 
 This will make the update (and therefore repaint) frequency on the client deterministic (and lower) which in turn will give us a more responsive UI.
+
+This entails the following
+- All codepaths which emitted Topics.JobUpdated now emit Topic.JobUpdatedInternal
+- Topic.JobUpdatedInternal is consumed by job-update-batcher, to push updates into a buffer
+- job-update-batcher emits Topic.JobUpdated once every X seconds (1 for now) with updates received in the last X seconds (we keep the most recent update for each job-id)
+- Topic.JobUpdated is consumed by the JobResolver (and the client)

--- a/src/client/ItemList.tsx
+++ b/src/client/ItemList.tsx
@@ -23,11 +23,15 @@ export const ItemList:FunctionComponent = () => {
   const handleCleanUpClicked = () => doCleanUp();
 
   useSubscription(Subscription.JobAdded, {
-    onSubscriptionData: () => refetchJobs(),
+    onSubscriptionData: () => {
+      refetchJobs(); // TODO: Let's do a targeted update here, instead of refetching the world.
+    },
   });
 
   useSubscription(Subscription.JobRemoved, {
-    onSubscriptionData: () => refetchJobs(),
+    onSubscriptionData: () => {
+      refetchJobs(); // TODO: Let's do a targeted update here, instead of refetching the world.
+    },
   });
 
   useSubscription(Subscription.JobUpdated);

--- a/src/model/Topic.ts
+++ b/src/model/Topic.ts
@@ -2,6 +2,7 @@ export enum Topic {
   JobAdded = "JobAdded",
   JobCancelled = "JobCancelled",
   JobRemoved = "JobRemoved",
-  JobUpdated = "JobUpdated",
+  JobUpdated = "JobUpdated", // This is emitted by job-update-batcher and consumed by the JobResolver (and the client)
+  JobUpdatedInternal = "JobUpdatedInternal", // This is emitted by ytqueue and consumed by job-update-batcher
   YTDLUpdateComplete = "YTDLUpdateComplete",
 }

--- a/src/server/YTQueue.ts
+++ b/src/server/YTQueue.ts
@@ -25,7 +25,7 @@ const onCompletion = async (error: Error, job: Job): Promise<void> => {
 
   logger.debug("Saving job");
   await job.save();
-  getPubSub().publish(Topic.JobUpdated, job);
+  getPubSub().publish(Topic.JobUpdatedInternal, job);
 
   logger.debug("Done");
   thunks.delete(job.id);
@@ -34,13 +34,13 @@ const onCompletion = async (error: Error, job: Job): Promise<void> => {
 const onAbort = async (job: Job): Promise<void> => {
   job.status = JobStatus.Canceled;
   await job.save();
-  getPubSub().publish(Topic.JobUpdated, job);
+  getPubSub().publish(Topic.JobUpdatedInternal, job);
   thunks.delete(job.id);
 };
 
 const onProgress = (job: Job, progress: JobProgress): void => {
   job.progress = progress;
-  getPubSub().publish(Topic.JobUpdated, job);
+  getPubSub().publish(Topic.JobUpdatedInternal, job);
 };
 
 export const addJobToQueue = (job: Job): void => {
@@ -52,7 +52,7 @@ export const addJobToQueue = (job: Job): void => {
     job.status = JobStatus.InProgress;
     logger.debug("save...");
     await job.save();
-    getPubSub().publish(Topic.JobUpdated, job);
+    getPubSub().publish(Topic.JobUpdatedInternal, job);
     logger.debug("Call download");
     const thunk = await download({
       job,
@@ -76,7 +76,7 @@ export const removeJobFromQueue = async (job: Job): Promise<void> => {
       thunk.abort();
       job.status = JobStatus.Canceled;
       await job.save();
-      getPubSub().publish(Topic.JobUpdated, job);
+      getPubSub().publish(Topic.JobUpdatedInternal, job);
     } else 
       logger.debug("Thunk not found.");
     

--- a/src/server/graphql/resolvers/JobResolver.ts
+++ b/src/server/graphql/resolvers/JobResolver.ts
@@ -1,3 +1,4 @@
+import "../../job-update-batcher";
 import { DownloadOptionsInput, Job, JobStatus } from "../../../model/Job";
 import { Role } from "../../../model/Role";
 import { Topic } from "../../../model/Topic";
@@ -49,11 +50,11 @@ export class JobResolver {
     return jobId;
   }
 
-  @Subscription({
-    topics: Topic.JobUpdated,
+  @Subscription(() => [Job], {
+    topics: (Topic.JobUpdated),
   })
-  jobUpdated(@Root() job: Job): Job {
-    return job;
+  jobUpdated(@Root() jobs: Job[]): Job[] {
+    return jobs;
   }
 
   // TODO: Pubsub updates should happen from the event handlers in the Job model, not from mutations.

--- a/src/server/job-update-batcher.ts
+++ b/src/server/job-update-batcher.ts
@@ -1,0 +1,44 @@
+/**
+ * This module listens for Topic.JobUpdatedInternal and accumulates job updates in a map.
+ * Periodically, this buffer is drained and the updates are sent to the client via
+ * Topics.JobUpdated event.
+ * 
+ * We use a map for accumulating updates because we want to send the latest update for every job.
+ */
+import { Job } from "../model/Job";
+import { Topic } from "../model/Topic";
+import { getLogger } from "../shared/logger";
+import { getPubSub } from "./pubsub";
+
+const rootLogger = getLogger("job-update-batcher");
+const buffer:Map<string, Job> = new Map();
+
+/**
+ * Listener for the Topic.JobUpdatedInternal event. This is where we update our buffer.
+ */
+const onJobUpdated = (job: Job): void => {
+  rootLogger.debug("job updated:", job.id);
+  // We want to retain the latest message for the job and discard older ones.
+  buffer.delete(job.id);
+  buffer.set(job.id, job);
+};
+getPubSub().subscribe(Topic.JobUpdatedInternal, onJobUpdated, {});
+
+const ncLogger = getLogger("notifyClient", rootLogger);
+/**
+ * This function is executed periodically. This is where we flush the buffer and send all updates
+ * to client.
+ * 
+ * Note: We actually only emit the Topic.JobUpdated event here. The actual "send to client" bit
+ * happens through the `jobUpdated` subscription in JobResolver.
+ */
+const notifyClient = (): void => {
+  if (buffer.size) {
+    ncLogger.debug("notify clients");
+    const entries = Array.from(buffer.values());
+    buffer.clear();
+    getPubSub().publish(Topic.JobUpdated, entries);
+  }
+  setTimeout(notifyClient, 1000);  // once every second.
+};
+notifyClient();


### PR DESCRIPTION
_(Just going to copy-paste the ADR here)_

## Problem

Currently, the server transmits progress updates for each job as an individual message on the websocket link. These messages are consumed by the client, which updates the progress and/or status for each job on the receipt of each message.

This setup works OK for a small number of jobs, but as soon as the number of in-progress jobs rises, the client spends more and more time repainting the job list. This results in a client UI which becomes less and less responsive.

## Proposed solution

Job status updates received from the external downloader will no longer be immediatekly put on the websocket. Instead, these updates will be gathered in a short term buffer on the server. A separate code path will periodically check the buffer for contents, and transmit them as a single websocket message if any updates are found. Any updates sent to the client will be removed from the buffer.

This will make the update (and therefore repaint) frequency on the client deterministic (and lower) which in turn will give us a more responsive UI.

This entails the following
- All codepaths which emitted Topics.JobUpdated now emit Topic.JobUpdatedInternal
- Topic.JobUpdatedInternal is consumed by job-update-batcher, to push updates into a buffer
- job-update-batcher emits Topic.JobUpdated once every X seconds (1 for now) with updates received in the last X seconds (we keep the most recent update for each job-id)
- Topic.JobUpdated is consumed by the JobResolver (and the client)